### PR TITLE
fix: initialize ProviderContainer before booting adapters

### DIFF
--- a/packages/jet/lib/adapters/jet_adapter.dart
+++ b/packages/jet/lib/adapters/jet_adapter.dart
@@ -10,25 +10,27 @@ abstract class JetAdapter {
 
 Future<Jet> bootApplication(
   JetConfig config, {
+  Jet? jet,
   Future<void> Function(Jet jet)? setupFinished,
 }) async {
-  Jet jet = Jet(config: config);
+  // Use provided Jet instance or create a new one
+  Jet currentJet = jet ?? Jet(config: config);
 
   for (final adapter in [
     ...defaultAdapters,
     ...config.adapters,
   ]) {
-    final jetObject = await adapter.boot(jet);
+    final jetObject = await adapter.boot(currentJet);
     if (jetObject != null) {
-      jet = jetObject;
+      currentJet = jetObject;
     }
   }
 
   if (setupFinished != null) {
-    await setupFinished(jet);
+    await setupFinished(currentJet);
   }
 
-  return jet;
+  return currentJet;
 }
 
 Future<Jet> bootFinished(Jet jet, JetConfig config) async {

--- a/packages/jet/lib/bootstrap/boot.dart
+++ b/packages/jet/lib/bootstrap/boot.dart
@@ -8,7 +8,23 @@ import 'package:jet/widgets/main/jet_app.dart';
 class Boot {
   static Future<Jet> start(JetConfig config) async {
     WidgetsFlutterBinding.ensureInitialized();
-    return bootApplication(config);
+
+    // Create the Jet instance first
+    final jet = Jet(config: config);
+
+    // Create the ProviderContainer BEFORE booting adapters
+    // This allows adapters to access the container during their boot process
+    final container = ProviderContainer(
+      overrides: [
+        jetProvider.overrideWith((ref) => jet),
+      ],
+    );
+
+    // Set the container on the Jet instance so adapters can access it
+    jet.setContainer(container);
+
+    // Now boot the application with the container already set
+    return bootApplication(config, jet: jet);
   }
 
   static Future<void> finished(Jet jet, JetConfig config) async {
@@ -19,20 +35,11 @@ class Boot {
 }
 
 Future<void> runJetApp({required Jet jet}) async {
-  // Create a ProviderContainer for accessing providers outside the widget tree
-  // This is used by adapters, services, and background tasks throughout the app
-  final container = ProviderContainer(
-    overrides: [
-      jetProvider.overrideWith((ref) => jet),
-    ],
-  );
-
-  // Set the container on the Jet instance so adapters and services can access it
-  jet.setContainer(container);
-
+  // The container is already created and set in Boot.start()
+  // Just run the app with the existing container
   runApp(
     UncontrolledProviderScope(
-      container: container,
+      container: jet.container,
       child: JetApp(jet: jet),
     ),
   );


### PR DESCRIPTION
Fixed LateInitializationError where NotificationsAdapter tried to access jet.container before it was initialized. Now the ProviderContainer is created and set on the Jet instance BEFORE adapters are booted, ensuring adapters can safely access the container during their boot process.

Changes:
- Move container creation from runJetApp() to Boot.start()
- Set container on Jet instance before calling bootApplication()
- Update bootApplication() to accept optional Jet parameter
- Adapters can now safely use jet.container in boot() method

Fixes issue where notifications adapter would crash with: 'Field _container has not been initialized'